### PR TITLE
feat: data provider class scaffolding and storage for gathered data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,168 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/providers/providers.py
+++ b/providers/providers.py
@@ -1,0 +1,80 @@
+import json
+import asyncio
+
+from datetime import datetime
+from urllib.parse import urlparse
+from aiohttp import ClientSession
+
+
+class BaseJSONProvider:
+    def __init__(self, url, prov_id=None, headers=None):
+        self._url = urlparse(url)
+        self._id = prov_id if prov_id else self._url.netloc
+        self._headers = headers if headers else {'content-type': 'application/json'}
+
+    def __str__(self) -> str:
+        return self._id
+
+    def _wrap(self, data) -> dict:
+        """wraps fetched data into storage-friendly dict"""
+        return dict(
+            id=self._id,
+            data=data,
+            timestamp=datetime.now().isoformat(),
+        )
+
+    async def _fetch_json(self, url, session) -> dict:
+        """asynchronously fetches data by given url, then parses JSON response into dict"""
+        async with session.get(url, headers=self._headers) as response:
+            data = await response.read()
+            return json.loads(data)
+
+    def process(self, data) -> dict:
+        """override this method if any processing of fetched data is required"""
+        return self._wrap(data)
+
+    async def collect(self) -> dict:
+        """the entrypoint of the Provider class, does all work of data-gathering"""
+        async with ClientSession() as session:
+            t = asyncio.ensure_future(self._fetch_json(self._url.geturl(), session))
+            data = await asyncio.gather(t)
+            return self.process(data)
+
+
+class GithubPullRequestsProvider(BaseJSONProvider):
+    def process(self, data):
+        """override process method to extract only meaningful data
+        from Github's PR list response.
+        """
+
+        processed = list()
+        for pull in data[0]:
+            processed.append(dict(
+                id=pull['number'],
+                author=pull['user']['login'],
+                created=pull['created_at'],
+                title=pull['title'],
+            ))
+        return self._wrap(processed)
+
+
+async def main(providers):
+    tasks = [p.collect() for p in providers]
+    for fut in asyncio.as_completed(tasks):
+        result = await fut
+        print('returns {}'.format(result))
+
+
+def get_providers():
+    return [
+        GithubPullRequestsProvider(
+            prov_id='github_core_pulls',
+            url='https://api.github.com/repos/sonm-io/core/pulls',
+            headers={'accept': 'application/vnd.github.mercy-preview+json'}
+        ),
+    ]
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(get_providers()))

--- a/providers/storage.py
+++ b/providers/storage.py
@@ -1,0 +1,63 @@
+import json
+from threading import Lock
+
+
+class Storage:
+    """Storage provides simple thread-save storage"""
+    mu = Lock()
+
+    def __init__(self, path):
+        # try to open file and load their content as JSON
+        # if it failed - file is empty, try to rewrite it with
+        # an empty dict
+        try:
+            with open(path, 'r') as f:
+                json.loads(f.read())
+                read_ok = True
+        except:
+            read_ok = False
+
+        if not read_ok:
+            with open(path, 'w') as f:
+                f.write(json.dumps({}))
+
+        self._path = path
+
+    def save_key(self, key, data):
+        """saves JSON-serializable data by given key"""
+        self.mu.acquire()
+        try:
+            current = self._load()
+            current[key] = data
+
+            serialized = json.dumps(current)
+            with open(self._path, 'w') as f:
+                f.write(serialized)
+
+        finally:
+            self.mu.release()
+
+    def load_key(self, key) -> dict:
+        """loads data by given key"""
+        data = self.load_all()
+        try:
+            v = data[key]
+        except KeyError:
+            v = None
+
+        return v
+
+    def load_all(self) -> dict:
+        """loads all data from storage"""
+        self.mu.acquire()
+        try:
+            data = self._load()
+        finally:
+            self.mu.release()
+
+        return data
+
+    def _load(self):
+        """reads data from state file, need to be protected by mutex"""
+        with open(self._path, 'r') as f:
+            return json.loads(f.read())

--- a/providers/storage_test.py
+++ b/providers/storage_test.py
@@ -1,0 +1,29 @@
+from providers.storage import Storage
+
+
+def test_storage(tmpdir):
+    tmp = tmpdir.mkdir('test').join('data.json')
+    print(tmp)
+
+    s = Storage(tmp)
+    data = s.load_all()
+
+    # empty storage must have no keys in it
+    assert len(data) == 0
+
+    # empty storage must return None
+    # for any key
+    v = s.load_key('foo')
+    assert v is None
+
+    s.save_key('bar', {'data': 'hello'})
+    s.save_key('baz', {'user': 'name'})
+
+    all = s.load_all()
+    assert 'bar' in all
+    assert 'data' in all['bar']
+    assert all['bar']['data'] == 'hello'
+
+    assert 'baz' in all
+    assert 'user' in all['baz']
+    assert all['baz']['user'] == 'name'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+aiohttp==3.3.2
+async-timeout==3.0.0
+atomicwrites==1.1.5
+attrs==18.1.0
+chardet==3.0.4
+idna==2.7
+idna-ssl==1.0.1
+more-itertools==4.2.0
+multidict==4.3.1
+pluggy==0.6.0
+py==1.5.3
+pytest==3.6.1
+six==1.11.0
+yarl==1.2.6


### PR DESCRIPTION
This commit introduces basic entities for data collecting:
- `BaseJSONProvider` hides aiohttp work to data loading, Github data provider implements Base provider and gather data from sonm-io/core repository.
- `Storage` class implements simpliest JSON-based k-v storage to keep loaded data between data-refresh sysles.