### PR TITLE
refactor: storage is singleton

### DIFF
--- a/providers/storage_test.py
+++ b/providers/storage_test.py
@@ -27,3 +27,17 @@ def test_storage(tmpdir):
     assert 'baz' in all
     assert 'user' in all['baz']
     assert all['baz']['user'] == 'name'
+
+
+def test_storage_singleton(tmpdir):
+    tmp = tmpdir.mkdir('test').join('data.json')
+
+    s1 = Storage(tmp)
+    s2 = Storage(tmp)
+
+    s1.save_key('test', {'a': 'b'})
+    v = s2.load_key('test')
+
+    # check that data written into first instance
+    # is available for second instance
+    assert v['a'] == 'b'


### PR DESCRIPTION
This commit change storage class behaviour to acts as singleton class.
It required to use the same instance of storage with http-backend (read)
and data-providers (write).